### PR TITLE
Fix alternating rows looking ugly in dolphin

### DIFF
--- a/Akava-Kv/Akava-Kv.kvconfig
+++ b/Akava-Kv/Akava-Kv.kvconfig
@@ -76,7 +76,7 @@ frame.patternsize=20
 [GeneralColors]
 dark.color=#2c2c2c
 tooltip.text.color=#2c2c2c
-alt.base.color=#2c2c2c
+alt.base.color=#2c2c2c00
 base.color=#2c2c2c
 light.color=#5f677f
 window.text.color=#ffffffc8


### PR DESCRIPTION
When using this theme with dolphin, the details view looks very ugly. This way, it looks cleaner (alternating rows "turned off")